### PR TITLE
Fixed willTransitionTo method, 'this' is bound to the Route that is…

### DIFF
--- a/constrainable.js
+++ b/constrainable.js
@@ -9,8 +9,8 @@ function isRegExp(val) {
 var Constrainable = {
   statics: {
     willTransitionTo : function(transition, params) {
-      if (!this.validatePath || !this.validateParams) return;
-      if (!this.validatePath(transition.path) || !this.validateParams(params)) {
+      if (!this.handler.validatePath || !this.handler.validateParams) return;
+      if (!this.handler.validatePath(transition.path) || !this.handler.validateParams(params)) {
         transition.redirect(this.redirectTo);
       }
     },


### PR DESCRIPTION
… about to transition to so we need to explicitly call this.handler.

This PR makes the mixin work for current version of react-router
